### PR TITLE
Add actionsFromClass method for use in extended Policy classes

### DIFF
--- a/src/policy.ts
+++ b/src/policy.ts
@@ -29,4 +29,16 @@ export default class Policy {
     })
     return newPolicy
   }
+
+  actionsFromClass(): void {
+    const actionNames = Object.getOwnPropertyNames(
+      this.constructor.prototype
+    ).filter((methodName) => methodName !== 'constructor')
+    this.actions = new Map(
+      actionNames.map((actionName) => [
+        actionName,
+        (): boolean => this[actionName](this.user, this.record),
+      ])
+    )
+  }
 }


### PR DESCRIPTION
Introduces a new method that can be added to the constructor of the extended policy class that will add all class methods to the actions map:

`this.actionsFromClass.apply(this)`

Using `apply(this)` allows us to use the scope of the extended policy within `Policy`, otherwise `this` will refer to the base `Policy` class, meaning that we'll only see methods such as  `can`, `add`, and `copy`, which is not what we want.

Open to any suggestions for simplifying this further.

Addresses #43