### PR TITLE
Remove todo section from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,37 +87,6 @@ In order to avoid passing user/policy/resource props to every usage of the
 </PunditProvider>
 ```
 
-## TODO
-
-- Improve typing for policy class
-  - Can expose an API/types where users manually construct (if ergonomic)
-  - Return new dynamic type based on actions given
-  - Can be used by the When/PunditProvider
-
-WIPS (thanks to Cedric)
-
-- https://www.typescriptlang.org/docs/handbook/2/keyof-types.html
-
-```js
-interface Policy<TPermission> {
-  (user: any, record: any): Map<TPermission, () => boolean>
-}
-
-const example = {
-  edit: true,
-  delete: false
-}
-
-type Action = keyof typeof example
-
-const g : Policy<Action> = {}
-
-New
-11:44
-Type '{}' is not assignable to type 'Policy<"edit" | "delete">'.
-  Type '{}' provides no match for the signature '(user: any, record: any): Map<"edit" | "delete", () => boolean>'.
-```
-
 ## License
 
 MIT


### PR DESCRIPTION
Given that we're extending the `Policy` class now, it seems that this approach is no longer needed?