### PR TITLE
Replace deprecated JSX namespace with ReactNode type

### DIFF
--- a/src/react/pundit-provider.tsx
+++ b/src/react/pundit-provider.tsx
@@ -1,4 +1,4 @@
-import React, { JSX, ReactElement, useMemo } from 'react'
+import React, { ReactNode, ReactElement, useMemo } from 'react'
 import Policy from '../policy'
 
 const PunditContext = React.createContext({ policy: new Policy(null, null) })
@@ -7,7 +7,7 @@ interface PunditProviderProps {
   policy: Policy
   user?: unknown
   record?: unknown
-  children: JSX.Element | JSX.Element[] | null
+  children: ReactNode | ReactNode[] | null
 }
 
 export const usePundit = (): { policy: Policy } => {

--- a/src/react/when.tsx
+++ b/src/react/when.tsx
@@ -1,8 +1,9 @@
+import { ReactNode } from 'react'
 import Policy from '../policy'
 import { usePundit } from './pundit-provider'
 
 interface WhenProps {
-  children: JSX.Element | null
+  children: ReactNode | null
   can: string
   policy?: Policy
   user?: unknown
@@ -15,7 +16,7 @@ export default function When({
   policy,
   user,
   record,
-}: WhenProps): JSX.Element | null {
+}: WhenProps): ReactNode | null {
   const { policy: hookPolicy } = usePundit()
   const paramPolicy = policy?.copy(user, record)
   const canPerformAction = paramPolicy


### PR DESCRIPTION
The documentation for the `JSX` namespace is as follows:

```
namespace JSX
@deprecated — Use React.JSX instead of the global JSX namespace.
```

Instead of moving to `React.JSX` I've moved to `ReactNode`.
