### PR TITLE
ci: reduce dependabot schedule interval to monthly for npm package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,6 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     commit-message:
       prefix: 'build: '


### PR DESCRIPTION
Since these packages updates are normally minor patch level updates for dev dependencies, such as eslint or type definitions that change very frequently, we can reduce the amount of noise in Git history by running dependabot less frequently.